### PR TITLE
Fix missing chart, grant exec to Azure managed id

### DIFF
--- a/MLB/permission_attendanceReportSproc.sql
+++ b/MLB/permission_attendanceReportSproc.sql
@@ -1,0 +1,2 @@
+/* assign permissions to the attendance report sproc for the Azure managed id login */
+GRANT EXECUTE ON MLB.[attendanceReportSproc] TO AgilitySQLUserReadonly;


### PR DESCRIPTION
For missing decades chart, grant exec permissions to the new Azure managed login