### PR TITLE
Implement SQL Temporal logging for NBA and NFL Roster tables

### DIFF
--- a/NBA/DDL_NBA_Roster_Temporal.sql
+++ b/NBA/DDL_NBA_Roster_Temporal.sql
@@ -1,0 +1,46 @@
+/* Implement SQL Server temporal table audit tracking for the NBA.Roster table. */
+
+-- Add Temporal Period timestamp fields to the existing Roster table
+if NOT EXISTS (select 1 from INFORMATION_SCHEMA.COLUMNS WHERE COLUMN_NAME='SysStartTime' AND TABLE_SCHEMA='NBA' and TABLE_Name='Roster') 
+ALTER TABLE NBA.Roster
+ADD
+    SysStartTime DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN
+        CONSTRAINT DF_NBARoster_SysStartTime DEFAULT SYSUTCDATETIME(),
+    SysEndTime DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN
+        CONSTRAINT DF_NBARoster_SysEndTime DEFAULT CONVERT(DATETIME2, '9999-12-31 23:59:59.9999999'),
+    PERIOD FOR SYSTEM_TIME (SysStartTime, SysEndTime);
+
+-- Create the history table, with matching schema
+if NOT EXISTS (select * from SYS.TABLES WHERE name='RosterHistory' and SCHEMA_NAME(schema_id) = 'NBA')
+CREATE TABLE NBA.RosterHistory
+(
+	[playerID] [int] NOT NULL,
+	[FirstName] [nvarchar](50) NULL,
+	[LastName] [nvarchar](50) NULL,
+	[Team] [nvarchar](50) NOT NULL,
+	[Position] [nvarchar](10) NOT NULL,
+	[Number] [varchar](5) NULL,
+	[Height] [nvarchar](6) NOT NULL,
+	[Weight] [nvarchar](3) NULL,
+	[DateOfBirth] [date] NOT NULL,
+	[College] [nvarchar](50) NOT NULL,
+    SysStartTime DATETIME2 NOT NULL,
+    SysEndTime DATETIME2 NOT NULL,
+)
+
+-- Turn on the change auditing to the history table
+ALTER TABLE NBA.Roster
+SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = NBA.RosterHistory, DATA_CONSISTENCY_CHECK = ON));
+
+-- Create some indexes to optimize history research
+CREATE INDEX IX_RosterHistoryDates ON NBA.RosterHistory (SysStartTime, SysEndTime);
+CREATE INDEX IX_RosterHistoryPlayer ON NBA.RosterHistory (playerID, SysStartTime, SysEndTime);
+
+--Validate the settings
+select 
+	SCHEMA_NAME(schema_id), 
+	name, 
+	temporal_type, 
+	temporal_type_desc, 
+	history_table = OBJECT_NAME(history_table_id) 
+from SYS.TABLES where name = 'roster'

--- a/NBA/DDL_NBA_Roster_Temporal_Rollback.sql
+++ b/NBA/DDL_NBA_Roster_Temporal_Rollback.sql
@@ -1,0 +1,26 @@
+/* rollback -- untemporal the table
+
+	-- Turn Off the change auditing to the history table
+	ALTER TABLE NBA.Roster
+	SET (SYSTEM_VERSIONING = OFF);
+
+	-- Drop temporal columns
+	ALTER TABLE AgilitySports.NBA.Roster DROP PERIOD FOR SYSTEM_TIME;
+	ALTER TABLE NBA.Roster DROP CONSTRAINT DF_NBARoster_SysStartTime;
+	ALTER TABLE NBA.Roster DROP CONSTRAINT DF_NBARoster_SysEndTime;
+	ALTER TABLE NBA.Roster DROP COLUMN SysStartTime;
+	ALTER TABLE NBA.Roster DROP COLUMN SysEndTime;
+
+	-- Drop history table
+	DROP TABLE NBA.RosterHistory
+
+	--Validate
+	select 
+		[Schema] = SCHEMA_NAME(schema_id), 
+		name, 
+		temporal_type, 
+		temporal_type_desc, 
+		history_table = SCHEMA_NAME(schema_id) + '.' + OBJECT_NAME(history_table_id) 
+	from SYS.TABLES where name = 'roster'
+
+*/

--- a/NBA/DDL_NBA_Roster_Temporal_Test.sql
+++ b/NBA/DDL_NBA_Roster_Temporal_Test.sql
@@ -1,0 +1,18 @@
+-- Unit test Temporal auditing of the NBA.Roster table
+
+DECLARE @Savecollege varchar(50);
+
+SELECT @Savecollege = College
+FROM NBA.Roster
+WHERE PlayerID = 8
+
+UPDATE NBA.Roster
+SET College = 'Audit test'
+WHERE PlayerID = 8
+
+UPDATE NBA.Roster
+SET college = @Savecollege
+WHERE PlayerID = 8
+
+SELECT *
+FROM NBA.RosterHistory

--- a/NFL/DDL_NFL_Roster_Temporal.sql
+++ b/NFL/DDL_NFL_Roster_Temporal.sql
@@ -1,0 +1,69 @@
+/* Implement SQL Server temporal table audit tracking for the NFL.Roster table. */
+
+-- Add Temporal Period timestamp fields to the existing Roster table
+if NOT EXISTS (select 1 from INFORMATION_SCHEMA.COLUMNS WHERE COLUMN_NAME='SysStartTime' AND TABLE_SCHEMA='NFL' and TABLE_Name='Roster') 
+ALTER TABLE NFL.Roster
+ADD
+    SysStartTime DATETIME2 GENERATED ALWAYS AS ROW START HIDDEN
+        CONSTRAINT DF_NFLRoster_SysStartTime DEFAULT SYSUTCDATETIME(),
+    SysEndTime DATETIME2 GENERATED ALWAYS AS ROW END HIDDEN
+        CONSTRAINT DF_NFLRoster_SysEndTime DEFAULT CONVERT(DATETIME2, '9999-12-31 23:59:59.9999999'),
+    PERIOD FOR SYSTEM_TIME (SysStartTime, SysEndTime);
+
+-- Create the history table, with matching schema
+if NOT EXISTS (select * from SYS.TABLES WHERE name='RosterHistory' and SCHEMA_NAME(schema_id) = 'NFL')
+CREATE TABLE NFL.RosterHistory
+(
+	[PlayerId] [int] NOT NULL,
+	[Name] [varchar](100) NOT NULL,
+	[FirstName] [varchar](100) NOT NULL,
+	[LastName] [varchar](100) NOT NULL,
+	[Team] [varchar](10) NOT NULL,
+	[Position] [varchar](10) NULL,
+	[FantasyPosition] [varchar](10) NULL,
+	[PositionCategory] [varchar](10) NULL,
+	[Height] [varchar](100) NULL,
+	[Weight] [int] NULL,
+	[Number] [int] NULL,
+	[CurrentStatus] [varchar](100) NULL,
+	[CurrentStatusColor] [varchar](100) NULL,
+	[BirthDateShortString] [date] NULL,
+	[Age] [smallint] NULL,
+	[AgeExact] [float] NULL,
+	[College] [varchar](100) NULL,
+	[CollegeDraftRound] [varchar](100) NULL,
+	[CollegeDraftPick] [varchar](100) NULL,
+	[ExperienceDigit] [varchar](100) NULL,
+	[PlayerUrlString] [varchar](100) NULL,
+	[TeamName] [varchar](100) NULL,
+	[TeamUrlString] [varchar](100) NULL,
+	[PhotoUrl] [varchar](300) NULL,
+	[PreferredHostedHeadshotUrl] [varchar](300) NULL,
+	[LowResPreferredHostedHeadshotUrl] [varchar](300) NULL,
+	[IsAvailableToPlay] [bit] NULL,
+	[Status] [varchar](100) NULL,
+	[InjuryStatus] [varchar](100) NULL,
+	[InjuryBodyPart] [varchar](100) NULL,
+	[ShortName] [varchar](100) NULL,
+	[TeamDetails] [varchar](100) NULL,
+	[CSName] [varchar](100) NULL,
+    SysStartTime DATETIME2 NOT NULL,
+    SysEndTime DATETIME2 NOT NULL
+)
+
+-- Turn on the change auditing to the history table
+ALTER TABLE NFL.Roster
+SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = NFL.RosterHistory, DATA_CONSISTENCY_CHECK = ON));
+
+-- Create some indexes to optimize history research
+CREATE INDEX IX_RosterHistoryDates ON NFL.RosterHistory (SysStartTime, SysEndTime);
+CREATE INDEX IX_RosterHistoryPlayer ON NFL.RosterHistory (playerID, SysStartTime, SysEndTime);
+
+--Validate the settings
+select 
+	SCHEMA_NAME(schema_id), 
+	name, 
+	temporal_type, 
+	temporal_type_desc, 
+	history_table = OBJECT_NAME(history_table_id) 
+from SYS.TABLES where name = 'roster'

--- a/NFL/DDL_NFL_Roster_Temporal_Rollback.sql
+++ b/NFL/DDL_NFL_Roster_Temporal_Rollback.sql
@@ -1,0 +1,26 @@
+/* rollback -- untemporal the table
+
+	-- Turn Off the change auditing to the history table
+	ALTER TABLE NFL.Roster
+	SET (SYSTEM_VERSIONING = OFF);
+
+	-- Drop temporal columns
+	ALTER TABLE AgilitySports.NFL.Roster DROP PERIOD FOR SYSTEM_TIME;
+	ALTER TABLE NFL.Roster DROP CONSTRAINT DF_NFLRoster_SysStartTime;
+	ALTER TABLE NFL.Roster DROP CONSTRAINT DF_NFLRoster_SysEndTime;
+	ALTER TABLE NFL.Roster DROP COLUMN SysStartTime;
+	ALTER TABLE NFL.Roster DROP COLUMN SysEndTime;
+
+	-- Drop history table
+	DROP TABLE NFL.RosterHistory
+
+	--Validate
+	select 
+		[Schema] = SCHEMA_NAME(schema_id), 
+		name, 
+		temporal_type, 
+		temporal_type_desc, 
+		history_table = SCHEMA_NAME(schema_id) + '.' + OBJECT_NAME(history_table_id) 
+	from SYS.TABLES where name = 'roster'
+
+*/

--- a/NFL/DDL_NFL_Roster_Temporal_Test.sql
+++ b/NFL/DDL_NFL_Roster_Temporal_Test.sql
@@ -1,0 +1,18 @@
+-- Unit test Temporal auditing of the NFL.Roster table
+
+DECLARE @SaveTeam varchar(50);
+
+SELECT @SaveTeam = Team
+FROM NFL.Roster
+WHERE PlayerID = 21936
+
+UPDATE NFL.Roster
+SET Team = 'Audit test'
+WHERE PlayerID = 21936
+
+UPDATE NFL.Roster
+SET Team = @SaveTeam
+WHERE PlayerID = 21936
+
+SELECT *
+FROM NFL.RosterHistory


### PR DESCRIPTION
Implement SQL Temporal logging for NBA and NFL Roster tables.
The usual script triplets: implementation, test, and rollback

DDL_NBA_Roster_Temporal.sql
DDL_NBA_Roster_Temporal_Test.sql
DDL_NBA_Roster_Temporal_Rollback.sql

DDL_NFL_Roster_Temporal.sql
DDL_NFL_Roster_Temporal_Test.sql
DDL_NFL_Roster_Temporal_Rollback.sql
