### PR TITLE
NFL CRUD - populate PositionCodes for NFL, drop 'name' field

### DIFF
--- a/NFL/DDL_NFL_Roster_Drop_Name.sql
+++ b/NFL/DDL_NFL_Roster_Drop_Name.sql
@@ -1,0 +1,16 @@
+/* 
+    Drop the "name" field on the existing NFL.Roster table. 
+        -Disable System Versioning
+        -Drop "name" from both the main and history tables
+        -Reenable versioning
+*/
+USE AgilitySports
+go
+
+ALTER TABLE NFL.Roster SET (SYSTEM_VERSIONING = OFF);
+
+ALTER TABLE NFL.Roster DROP COLUMN [name];
+ALTER TABLE NFL.RosterHistory DROP COLUMN [name];
+
+ALTER TABLE NFL.Roster
+SET (SYSTEM_VERSIONING = ON (HISTORY_TABLE = NFL.RosterHistory));

--- a/System/popSportsPositionCodes.sql
+++ b/System/popSportsPositionCodes.sql
@@ -21,5 +21,31 @@ values
 ('NBA', 'PG', 'Point Guard'),
 ('NBA', 'SG', 'Shooting Guard')
 
+/* populate the PositionCodes table, for NFL */
+insert into dbo.PositionCodes (Sport, PositionCode, PositionDesc)
+values
+('NFL', 'C', 'Center'),
+('NFL', 'CB', 'Cornerback'),
+('NFL', 'DB', 'Defensive Back'),
+('NFL', 'DE', 'Defensive End'),
+('NFL', 'DL', 'Defensive Lineman'),
+('NFL', 'DT', 'Defensive Tackle'),
+('NFL', 'FB', 'Fullback'),
+('NFL', 'G', 'Guard'),
+('NFL', 'ILB', 'Inside Linebacker'),
+('NFL', 'K', 'Kicker'),
+('NFL', 'LB', 'Linebacker'),
+('NFL', 'LS', 'Long Snapper'),
+('NFL', 'NT', 'Nose Tackle'),
+('NFL', 'OL', 'Offensive Lineman'),
+('NFL', 'OLB', 'Outside Linebacker'),
+('NFL', 'OT', 'Offensive Tackle'),
+('NFL', 'P', 'Punter'),
+('NFL', 'QB', 'Quarterback'),
+('NFL', 'RB', 'Running Back'),
+('NFL', 'S', 'Safety'),
+('NFL', 'TE', 'Tight End'),
+('NFL', 'WR', 'Wide Receiver');
+
 select *
 from dbo.PositionCodes


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

SQL changes needed for the NFL CRUD additional functionality.
- Add codeset for NFL to PositionCodes table
- Drop the NFL.roster.name field (leave firstName and lastName)

## Dependencies
- AgilitySports_API NFL CRUD changes
- AgilitySports_Web NFL CRUD changes

Fixes or Implements # (issue) NFL CRUD - SQL Changes [#72](https://github.com/smagara/AgilitySports_web/issues/72)

## Type of change: Enhancement

Please check relevant options

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [x] Local unit testing with REST Client from AgilitySports_API
- [x] Local unit testing with AgilitySports_Web angular site

## Checklist:

- [ ] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules