### PR TITLE
Update height fields to eliminate interior spaces

### DIFF
--- a/Common/Height_Cleanup.sql
+++ b/Common/Height_Cleanup.sql
@@ -1,0 +1,28 @@
+/* 
+	Update height fields to eliminate interior spaces.
+	The formats were not consistent between sports.
+	New format is 5'11" not 5' 11", for example.
+*/
+
+Use AgilitySports;
+GO
+
+BEGIN TRAN
+
+	UPDATE NFL.Roster
+		SET Height = replace(Height, ' ', '')
+	OUTPUT
+		INSERTED.PlayerId,
+		INSERTED.LastName,
+		DELETED.Height AS Old_Height,
+		INSERTED.Height AS New_Height
+
+	UPDATE NBA.Roster
+		SET Height = replace(Height, ' ', '')
+	OUTPUT
+		INSERTED.PlayerId,
+		INSERTED.LastName,
+		DELETED.Height AS Old_Height,
+		INSERTED.Height AS New_Height
+
+COMMIT TRAN


### PR DESCRIPTION
<!-- filepath: .github/PULL_REQUEST_TEMPLATE.md -->

## Description

Update height fields to eliminate interior spaces.
The formats were not consistent between sports.
New format is 5'11" not 5' 11", for example.
This script will allow the UI to edit smoothly existing records that expect a cleaner format.

## Dependencies
- AgilitySports Web PR for Height validation

Fixes or Implements # (issue) #22 

## Type of change
TSQL Data update

Please check relevant options

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Edit/Add existing NBA and NFL roster players without error

## Checklist:

- [ ] My code follows the style guidelines of this project, formatting and lint-ing
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation, if applicable
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules